### PR TITLE
onClick시 카메라 줌인 이벤트 구현

### DIFF
--- a/src/components/DataCanvas/DataCanvas.tsx
+++ b/src/components/DataCanvas/DataCanvas.tsx
@@ -1,10 +1,12 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 import styles from './DataCanvas.module.scss';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
 import PlaneGeometry from './PlaneGeometry';
 import Graph from './Graph/Graph';
+import ZoomController from './Graph/ZoomController';
+import { Vector3 } from 'three';
 
 const DataCanvas: FunctionComponent = function () {
   const tempInfo = [
@@ -35,16 +37,24 @@ const DataCanvas: FunctionComponent = function () {
   /* camera setting */
   const camera = new THREE.OrthographicCamera();
   camera.zoom = 100;
-  camera.position.set(-10, 10, 10);
   camera.near = 1;
   camera.far = 1000;
+
+  const [zoom, setZoom] = useState<boolean>(false);
+  const [focus, setFocus] = useState<Vector3>();
+
+  const zoomToFocus = (focusObj) => {
+    setZoom(!zoom);
+    setFocus(focusObj);
+  };
 
   return (
     <div className={styles.container}>
       <Canvas dpr={[1, 2]} orthographic shadows camera={camera}>
         <ambientLight intensity={0.1} />
         <directionalLight position={[0, 10, 10]} castShadow intensity={2} shadow-camera-far={70} />
-        <Graph info={tempInfo} boxSize={BOX_SIZE} />
+        <Graph info={tempInfo} boxSize={BOX_SIZE} zoomToFocus={zoomToFocus} />
+        <ZoomController zoom={zoom} focus={focus} />
         <PlaneGeometry width={GROUND_WIDTH} length={GROUND_LENGHT} />
         <OrbitControls />
       </Canvas>

--- a/src/components/DataCanvas/Graph/Bar/Bar.tsx
+++ b/src/components/DataCanvas/Graph/Bar/Bar.tsx
@@ -1,7 +1,7 @@
-import { ThreeEvent, useFrame } from '@react-three/fiber';
 import { FunctionComponent, useRef, useState } from 'react';
-import { Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { Text } from '@react-three/drei';
 
 type BarProps = {
   data: [string, number, number];
@@ -9,26 +9,19 @@ type BarProps = {
 };
 
 const Bar: FunctionComponent<BarProps> = function ({ data, boxSize }) {
+  const [clicked, setClicked] = useState(false);
   const meshRef = useRef(null);
   const textRef = useRef(null);
-  const [clicked, setClicked] = useState(false);
 
   const year = data[0];
   const posX = data[2][0];
   const figure = data[1];
 
   const color = new THREE.Color();
-  // const cameraPos = new THREE.Vector3();
   const fontProps = {
     font: '/fonts/noto-sans-kr-900.woff',
     fontSize: 0.1,
-    // lineHeight: 1,
     'material-toneMapped': false,
-  };
-
-  const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    setClicked(!clicked);
   };
 
   // useFrame의 변수 state를 이용하여 ref값의 변화를 주니까
@@ -42,20 +35,12 @@ const Bar: FunctionComponent<BarProps> = function ({ data, boxSize }) {
       textRef.current.position.set(posX, height, -boxSize * 2 + 0.01);
       meshRef.current.scale.set(boxSize, height, boxSize);
     }
-    meshRef.current.material.color.lerp(color.set(clicked ? '#15e8ef' : '#353535'), 0.1);
-    // if (clicked) {
-    //   state.camera.lookAt(meshRef.current.position);
-    //   state.camera.position.lerp(cameraPos.set(posX, boxSize + 1, boxSize + 1), 0.5);
-    // } else {
-    //   state.camera.lookAt(0, 0, 0);
-    //   state.camera.position.lerp(cameraPos.set(-10, 10, 10), 0.5);
-    // }
-    // state.camera.updateProjectionMatrix();
+    meshRef.current.material.color.lerp(color.set(clicked ? '#15e8ef' : '#353535'), 0.3);
   });
 
   return (
-    <group>
-      <mesh ref={meshRef} onClick={handleClick} castShadow receiveShadow>
+    <>
+      <mesh ref={meshRef} castShadow receiveShadow onClick={() => setClicked(!clicked)}>
         <boxGeometry />
         <meshStandardMaterial roughness={0.2} color="#353535" />
       </mesh>
@@ -64,7 +49,7 @@ const Bar: FunctionComponent<BarProps> = function ({ data, boxSize }) {
           {year}
         </Text>
       </mesh>
-    </group>
+    </>
   );
 };
 

--- a/src/components/DataCanvas/Graph/Graph.tsx
+++ b/src/components/DataCanvas/Graph/Graph.tsx
@@ -5,11 +5,11 @@ import Bar from './Bar';
 type GraphProps = {
   info: object;
   boxSize: number;
+  zoomToFocus: (focusObj: THREE.Vector3) => void;
 };
 
-const Graph: FunctionComponent<GraphProps> = function ({ info, boxSize }) {
+const Graph: FunctionComponent<GraphProps> = function ({ info, boxSize, zoomToFocus }) {
   const figureNormalized = useNormalization(info, 'figure');
-
   // 나중에는 data가 많아질것을 대비하여
   // 연산을 줄이기 위하여 useMemo를 사용
   const data = useMemo(() => {
@@ -20,14 +20,20 @@ const Graph: FunctionComponent<GraphProps> = function ({ info, boxSize }) {
     return temp;
   }, [info, figureNormalized, boxSize]);
 
-  console.log(data.length);
-
   return (
-    <mesh position={[(-boxSize * data.length) / 2, 0, boxSize]}>
+    <>
       {data.map((bar, idx) => (
-        <Bar key={idx} data={bar} boxSize={boxSize} />
+        <group
+          key={idx}
+          onClick={(e) => {
+            e.stopPropagation();
+            zoomToFocus(e.object.position);
+          }}
+        >
+          <Bar data={bar} boxSize={boxSize} />
+        </group>
       ))}
-    </mesh>
+    </>
   );
 };
 

--- a/src/components/DataCanvas/Graph/ZoomController/ZoomController.tsx
+++ b/src/components/DataCanvas/Graph/ZoomController/ZoomController.tsx
@@ -1,0 +1,29 @@
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+type ZoomControllerProps = {
+  zoom: boolean;
+  focus: THREE.Vector3;
+};
+
+const ZoomController = function ({ zoom, focus }: ZoomControllerProps) {
+  const pos = new THREE.Vector3();
+  const look = new THREE.Vector3();
+
+  return useFrame((state) => {
+    if (zoom) {
+      state.camera.zoom = 200;
+      pos.set(focus.x, focus.y, focus.z + 5);
+      look.set(focus.x, focus.y, focus.z - 5);
+    } else {
+      state.camera.zoom = 100;
+      pos.set(-10, 10, 10);
+      look.set(0, 0, 0);
+    }
+    state.camera.position.lerp(pos, 0.3);
+    state.camera.lookAt(look);
+    state.camera.updateProjectionMatrix();
+  });
+};
+
+export default ZoomController;

--- a/src/components/DataCanvas/Graph/ZoomController/index.ts
+++ b/src/components/DataCanvas/Graph/ZoomController/index.ts
@@ -1,0 +1,3 @@
+import ZoomController from './ZoomController';
+
+export default ZoomController;


### PR DESCRIPTION
<p align="center"><img width="512" alt="image" src="https://user-images.githubusercontent.com/80577900/172315565-c3bd1c0f-e030-430c-966b-b4ede3fdb781.png" > </p>



>  - 🤦🏽‍♂️ DataCanvas안에 Graph와 각각의 막대 수치인 Bar로 컴포넌트를 나눠 폴더 구조를 잡았습니다. 그 과정에서 Bar 컴포넌트 내 useFrame 함수 안에서 클릭 이벤트로 target 컬러 변경 및 카메라 위치까지 한꺼번에 해결을 하려다보니까 명확성이 떨어지고 렌더링이 꼬이게 되었습니다. 하지만 검색하던 중 useFrame 함수를 여러개 쓴다해서 성능이 떨어진다는건 아니라는 결과가 나와서 컴포넌트 별로 기능을 나누게 되었습니다.

- < `Bar.tsx` >
타겟하는 clicked state에 따라 그래프 바의 컬러 변경을 담당.
- < `DataCanvas.tsx` >
서버에서 받아온 데이터를 `Graph` 컴포넌트에, 그리고 `ZoomController` 컴포넌트에서 사용할 props들을 전달해주는 역할
- < `Graph.tsx` >
`DataCanvas`에서 받아온 데이터를 map 함수를 이용하여 각 `Bar` 컴포넌트 제작.
- < `ZoomController` >
`DataCanvas`에서 받아온 camera관련 zoom, focus props를 이용하여 useFrame 안에서 onClick이벤트로 카메라의 position 및 lookAt이 부드럽게 변경되게 애니메이션.